### PR TITLE
Fix missing files to the test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include CHANGELOG.md
 include tox.ini
+include test/utils.py
+recursive-include test/fixtures *.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include CHANGELOG.md
 include tox.ini
-include test/utils.py
-recursive-include test/fixtures *.txt
+recursive-include test *.txt *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = ["pre-commit", "isort", "flake8", "black", "pyproject-flake8"]
 benchmark = ["pytest", "pytest-benchmark"]
 doc = ["sphinx", "sphinx_book_theme", "myst-parser"]
 
+[tool.setuptools]
+packages = ["linkify_it", "test"]
+
 [tool.setuptools.dynamic]
 version = {attr = "linkify_it.__version__"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ dev = ["pre-commit", "isort", "flake8", "black", "pyproject-flake8"]
 benchmark = ["pytest", "pytest-benchmark"]
 doc = ["sphinx", "sphinx_book_theme", "myst-parser"]
 
-[tool.setuptools]
-packages = ["linkify_it", "test"]
-
 [tool.setuptools.dynamic]
 version = {attr = "linkify_it.__version__"}
 


### PR DESCRIPTION
The following missing files were added to test:
- utils.py
- fixtures/links.txt
- fixtures/no_links.txt
- \_\_init__.py

I ran tests and success.
```
wget https://test-files.pythonhosted.org/packages/be/ba/02c101e77a324fb292120c90084fb4dc712c063f5244f9f6a48447490fb9/linkify-it-py-2.0.1.dev6.tar.gz
tar xzfv linkify-it-py-2.0.1.dev6.tar.gz
cd linkify-it-py-2.0.1.dev6
pip install tox
tox
```