### PR TITLE
Add support for unicode email addresses (RFC 6530 and following)

### DIFF
--- a/linkify_it/ucre.py
+++ b/linkify_it/ucre.py
@@ -40,7 +40,7 @@ SRC_PORT = (
 
 # Allow anything in markdown spec, forbid quote (") at the first position
 # because emails enclosed in quotes are far more common
-SRC_EMAIL_NAME = '[\\-:&=\\+\\$,\\.a-zA-Z0-9_][\\-:&=\\+\\$,\\"\\.a-zA-Z0-9_]*'
+SRC_EMAIL_NAME = '[\\-:&=\\+\\$,\\.\\w][\\-:&=\\+\\$,\\"\\.\\w]*'
 
 SRC_XN = "xn--[a-z0-9\\-]{1,59}"
 

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -294,6 +294,9 @@ example.com/䨹
 
 президент.рф
 
+grå@grå.org
+
+grå2@grå.org
 
 % Links below provided by diaspora* guys, to make sure regressions will not happen.
 % Those left here for historic reasons.


### PR DESCRIPTION
This is as good as it can be using the builtin re module. Using the regex module would permit another improvement.

As it stands, this matches å as a combined character, which is by far the most common way to encode å. It does not match two things:
 - 'a' + combining ring above
 - ZWJ, which is required e.g. for the word 'sri' when written using sinhala, the most common script on Sri Lanka.
 
Switching to the regex module would permit detecting both of those, but they're rare cases and it's not obvious to me that catching some rare cases justifiies pulling in another module.