### PR TITLE
fix: port linkify-it 5.0.1 and 5.0.2 scan-loop fixes

### DIFF
--- a/benchmark/bench_quadratic.py
+++ b/benchmark/bench_quadratic.py
@@ -1,0 +1,286 @@
+"""Reproduce the quadratic scan-loop behavior.
+
+``LinkifyIt.match()`` exhibits quadratic slowdown on text containing many fuzzy
+email candidates. The scan loop in ``linkify_it/main.py`` repeatedly slices the
+remaining tail and runs an unanchored ``re.search`` over it on each iteration.
+
+Two upstream JavaScript fixes were never ported to this package:
+
+* linkify-it 5.0.1 -- GHSA-22p9-wv53-3rq4 / CVE-2026-48801
+  "Quadratic algorithmic complexity in LinkifyIt#match scan loop"
+* linkify-it 5.0.2 -- GHSA-v245-v573-v5vm / CVE-2026-59887
+  "Quadratic-complexity DoS via the ``mailto:`` validator scan-loop"
+
+This benchmark covers both cases, along with controls that isolate linkify as
+the source of the slowdown. Run it before and after porting the upstream fixes:
+the ``ratio`` column should fall from roughly 4x per input doubling (quadratic)
+to roughly 2x (linear).
+
+Usage::
+
+    python benchmark/bench_quadratic.py
+    python benchmark/bench_quadratic.py --max-kb 64    # full advisory table
+    python benchmark/bench_quadratic.py --suite render
+"""
+
+import argparse
+import platform
+import time
+from collections.abc import Callable, Iterator
+
+import linkify_it
+from linkify_it import LinkifyIt
+
+try:
+    import markdown_it
+    from markdown_it import MarkdownIt
+except ImportError:  # pragma: no cover - markdown-it-py is an extra
+    markdown_it = None  # type: ignore[assignment]
+    MarkdownIt = None  # type: ignore[assignment, misc]
+
+# Signature shared by everything we time: LinkifyIt.match and
+# MarkdownIt.render both take the payload and return a value we discard.
+TimedCall = Callable[[str], object]
+
+KB = 1024
+
+# Timing the first call would fold in one-off ``re`` compilation, which is
+# large enough at 4 KB to hide the growth curve. Warm up on a small payload.
+WARMUP_KB = 1
+
+# "a@b.com " repeated. Fuzzy email candidates drive the match() scan loop.
+EMAIL_UNIT = "a@b.com "
+
+# "mailto:" repeated. The ":" is a valid email-name char, so "mailto:mailto:..."
+# chains into O(n) schema hits, each running the validator to the end of the tail.
+MAILTO_UNIT = "mailto:"
+
+# Consumed by an inline rule first, so this payload should stay linear.
+HTTP_UNIT = "http://a.com "
+
+# Timings published in GHSA-8m2q-wq3r-6hq8, measured by the reporter through
+# MarkdownIt("gfm-like").render() against linkify-it-py 2.1.0.
+REPORTED_RENDER_SECONDS: dict[int, float] = {8: 1.07, 16: 3.90, 32: 15.5, 64: 62.0}
+
+# Same advisory: the commonmark preset, with linkify off, on a 32 KB payload.
+REPORTED_CONTROL_SECONDS = 0.013
+
+
+def print_environment() -> None:
+    print(f"python        : {platform.python_version()} ({platform.machine()})")
+    print(f"linkify-it-py : {linkify_it.__version__}")
+    print(f"              : {linkify_it.__file__}")
+    if markdown_it is not None:
+        print(f"markdown-it-py: {markdown_it.__version__}")
+    print()
+
+
+def repeat_to(unit: str, kb: int) -> str:
+    """Build a payload of about ``kb`` kibibytes by repeating ``unit``."""
+    return unit * (kb * KB // len(unit))
+
+
+def measure(fn: TimedCall, text: str) -> float:
+    """Return the wall-clock seconds ``fn(text)`` takes."""
+    start = time.perf_counter()
+    fn(text)
+    return time.perf_counter() - start
+
+
+def warm_up(fn: TimedCall, unit: str) -> None:
+    """Prime ``re`` caches so the first timed size is not an outlier."""
+    fn(repeat_to(unit, WARMUP_KB))
+
+
+def doubling_sizes(max_kb: int, start_kb: int = 4) -> Iterator[int]:
+    """Yield 4, 8, 16, ... kibibytes up to and including ``max_kb``."""
+    kb = start_kb
+    while kb <= max_kb:
+        yield kb
+        kb *= 2
+
+
+def eval(ratios: list[float]) -> str:
+    """Classify growth from the per-doubling time ratios."""
+    if not ratios:
+        return "not enough data points"
+
+    average = sum(ratios) / len(ratios)
+    if average >= 3.0:
+        return f"QUADRATIC: {average:.2f}x per doubling (quadratic is ~4x)"
+    if average <= 2.5:
+        return f"linear: {average:.2f}x per doubling (linear is ~2x)"
+    return f"inconclusive: {average:.2f}x per doubling"
+
+
+def run_scaling(
+    title: str,
+    unit: str,
+    fn: TimedCall,
+    max_kb: int,
+    reported: dict[int, float] | None = None,
+) -> None:
+    """Time ``fn`` over doubling payload sizes and print a scaling table."""
+    print(f"=== {title} ===")
+    print(f'payload: "{unit}" repeated')
+    print()
+
+    header = f"{'size':>7} {'n (bytes)':>11} {'time':>12} {'t/n^2':>14} {'ratio':>8}"
+    if reported:
+        header += f" {'reported':>11}"
+    print(header)
+
+    warm_up(fn, unit)
+
+    previous: float | None = None
+    ratios: list[float] = []
+    for kb in doubling_sizes(max_kb):
+        text = repeat_to(unit, kb)
+        elapsed = measure(fn, text)
+        n = len(text)
+
+        if previous is None:
+            ratio = "--"
+        else:
+            ratios.append(elapsed / previous)
+            ratio = f"{ratios[-1]:.2f}x"
+        previous = elapsed
+
+        row = (
+            f"{kb:>4} KB {n:>11} {elapsed:>10.3f} s "
+            f"{elapsed / n**2 * 1e9:>11.3f}e-9 {ratio:>8}"
+        )
+        if reported:
+            expected = reported.get(kb)
+            row += f" {expected:>9.2f} s" if expected else f" {'-':>11}"
+        print(row, flush=True)
+
+    print(f"-> {eval(ratios)}")
+    print()
+
+
+def require_markdown_it() -> bool:
+    """Return ``True`` if markdown-it-py is importable, else explain and skip."""
+    if MarkdownIt is not None:
+        return True
+    print("(skipped: markdown-it-py is not installed -- pip install markdown-it-py)")
+    print()
+    return False
+
+
+def suite_email(max_kb: int) -> None:
+    linkify = LinkifyIt()
+    run_scaling(
+        "fuzzy email scan loop, LinkifyIt.match() -- CVE-2026-48801",
+        EMAIL_UNIT,
+        linkify.match,
+        max_kb,
+    )
+
+
+def suite_mailto(max_kb: int) -> None:
+    linkify = LinkifyIt()
+    run_scaling(
+        "mailto: validator scan loop, LinkifyIt.match() -- CVE-2026-59887",
+        MAILTO_UNIT,
+        linkify.match,
+        max_kb,
+    )
+
+
+def suite_render(max_kb: int) -> None:
+    """Reproduce the advisory's own configuration, end to end."""
+    if not require_markdown_it():
+        return
+
+    md = MarkdownIt("gfm-like")
+    run_scaling(
+        "MarkdownIt('gfm-like').render(), linkify on -- advisory configuration",
+        EMAIL_UNIT,
+        md.render,
+        max_kb,
+        reported=REPORTED_RENDER_SECONDS,
+    )
+
+
+def suite_controls(max_kb: int) -> None:
+    """Show that linkify, not the gfm-like preset, is the trigger."""
+    if not require_markdown_it():
+        return
+
+    print("=== controls ===")
+    print()
+
+    text = repeat_to(EMAIL_UNIT, max_kb)
+
+    commonmark = MarkdownIt("commonmark")
+    warm_up(commonmark.render, EMAIL_UNIT)
+    baseline = measure(commonmark.render, text)
+    print(
+        f"{max_kb} KB email payload, commonmark (linkify off) : "
+        f"{baseline:>9.4f} s   (reported {REPORTED_CONTROL_SECONDS:.3f} s"
+        f" at 32 KB)"
+    )
+
+    gfm_off = MarkdownIt("gfm-like")
+    gfm_off.options["linkify"] = False
+    warm_up(gfm_off.render, EMAIL_UNIT)
+    print(
+        f"{max_kb} KB email payload, gfm-like, linkify=False  : "
+        f"{measure(gfm_off.render, text):>9.4f} s"
+    )
+
+    gfm_on = MarkdownIt("gfm-like")
+    warm_up(gfm_on.render, EMAIL_UNIT)
+    on = measure(gfm_on.render, text)
+    print(
+        f"{max_kb} KB email payload, gfm-like, linkify=True   : "
+        f"{on:>9.4f} s   ({on / baseline:.0f}x slower)"
+    )
+    print()
+
+    run_scaling(
+        "http:// payload -- consumed by an inline rule, expected to stay linear",
+        HTTP_UNIT,
+        gfm_on.render,
+        max_kb,
+    )
+
+
+SUITES: dict[str, Callable[[int], None]] = {
+    "email": suite_email,
+    "mailto": suite_mailto,
+    "render": suite_render,
+    "controls": suite_controls,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--max-kb",
+        type=int,
+        default=32,
+        help="largest payload size in KiB (default: 32; use 64 for the"
+        " full advisory table, which takes about a minute)",
+    )
+    parser.add_argument(
+        "--suite",
+        choices=["all", *SUITES],
+        default="all",
+        help="which measurement to run (default: all)",
+    )
+    args = parser.parse_args()
+
+    print_environment()
+
+    names = list(SUITES) if args.suite == "all" else [args.suite]
+    for name in names:
+        SUITES[name](args.max_kb)
+
+
+if __name__ == "__main__":
+    main()

--- a/linkify_it/main.py
+++ b/linkify_it/main.py
@@ -21,6 +21,27 @@ def _index_of(text, search_value):
     return result
 
 
+def _at(candidates, position):
+    """Item at ``position``, or ``None`` once the list is exhausted."""
+    return candidates[position] if position < len(candidates) else None
+
+
+def _choose(a, b):
+    """Return whichever candidate should be emitted first.
+
+    The earlier start wins; on equal starts the longer match wins. A full tie
+    keeps ``a``, so the order the candidates are folded in sets the priority.
+    ``None`` means the corresponding list has no candidate left.
+    """
+    if a is None:
+        return b
+    if b is None:
+        return a
+    if a.index != b.index:
+        return a if a.index < b.index else b
+    return a if a.last_index >= b.last_index else b
+
+
 class SchemaError(Exception):
     """Linkify schema error"""
 
@@ -41,8 +62,10 @@ class Match:
         url (str): Normalized url of matched string.
 
     Args:
-        linkifyit (:class:`linkify_it.main.LinkifyIt`) LinkifyIt object
-        shift (int): text searh position
+        text (str): text the match was found in
+        schema (str): link schema, empty for fuzzy links
+        index (int): first position of matched string
+        last_index (int): next position after matched string
     """
 
     def __repr__(self):
@@ -50,17 +73,35 @@ class Match:
             f"{self.__class__.__module__}.{self.__class__.__name__}({self.__dict__!r})"
         )
 
-    def __init__(self, linkifyit, shift):
-        start = linkifyit._index
-        end = linkifyit._last_index
-        text = linkifyit._text_cache[start:end]
+    def __init__(self, text, schema, index, last_index):
+        raw = text[index:last_index]
 
-        self.schema = linkifyit._schema.lower()
-        self.index = start + shift
-        self.last_index = end + shift
-        self.raw = text
-        self.text = text
-        self.url = text
+        self.schema = schema.lower()
+        self.index = index
+        self.last_index = last_index
+        self.raw = raw
+        self.text = raw
+        self.url = raw
+
+
+class _Candidate:
+    """A single hit found by one of the scan passes of :meth:`LinkifyIt.match`.
+
+    Every pass collects all of its hits up front, so no pass ever rescans a tail
+    that an earlier one already walked.
+
+    Args:
+        schema (str): link schema, empty for fuzzy links
+        index (int): first position of matched string
+        last_index (int): next position after matched string
+    """
+
+    __slots__ = ("index", "last_index", "schema")
+
+    def __init__(self, schema, index, last_index):
+        self.schema = schema
+        self.index = index
+        self.last_index = last_index
 
 
 class LinkifyIt:
@@ -167,10 +208,6 @@ class LinkifyIt:
 
         return 0
 
-    def _reset_scan_cache(self):
-        self._index = -1
-        self._text_cache = ""
-
     def _create_validator(self, regex):
         def func(text, pos):
             tail = text[pos:]
@@ -193,8 +230,8 @@ class LinkifyIt:
 
         return func
 
-    def _create_match(self, shift):
-        match = Match(self, shift)
+    def _create_match(self, text, schema, index, last_index):
+        match = Match(text, schema, index, last_index)
         self._compiled[match.schema]["normalize"](match)
         return match
 
@@ -226,12 +263,6 @@ class LinkifyIt:
             self._opts = self.default_options
         else:
             self._opts = self.default_options
-
-        # Cache last tested result. Used to skip repeating steps on next `match` call.
-        self._index = -1
-        self._last_index = -1  # Next scan position
-        self._schema = ""
-        self._text_cache = ""
 
         if schemas:
             self.default_schemas.update(schemas)
@@ -367,10 +398,6 @@ class LinkifyIt:
             "(" + re_schema_test + ")|(" + self.re["host_fuzzy_test"] + ")|@"
         )
 
-        # Cleanup
-
-        self._reset_scan_cache()
-
     def add(self, schema, definition):
         """Add new rule definition. (chainable)
 
@@ -416,51 +443,27 @@ class LinkifyIt:
         Returns:
             bool: ``True`` if a linkable pattern was found, otherwise it is ``False``.
         """
-        self._text_cache = text
-        self._index = -1
-
         if not len(text):
             return False
 
         if re.search(self.re["schema_test"], text, flags=re.IGNORECASE):
-            regex = self.re["schema_search"]
-            last_index = 0
-            matched_iter = re.finditer(regex, text[last_index:], flags=re.IGNORECASE)
+            matched_iter = re.finditer(
+                self.re["schema_search"], text, flags=re.IGNORECASE
+            )
             for matched in matched_iter:
-                last_index = matched.end(0)
-                m = (matched.group(), matched.groups()[0], matched.groups()[1])
-                length = self.test_schema_at(text, m[2], last_index)
-                if length:
-                    self._schema = m[2]
-                    self._index = matched.start(0) + len(m[1])
-                    self._last_index = matched.start(0) + len(m[0]) + length
-                    break
+                if self.test_schema_at(text, matched.group(2), matched.end(0)):
+                    return True
 
         if self._opts.get("fuzzy_link") and self._compiled.get("http:"):
             # guess schemaless links
-            matched_tld = re.search(
-                self.re["host_fuzzy_test"], text, flags=re.IGNORECASE
-            )
-            if matched_tld:
-                tld_pos = matched_tld.start(0)
-            else:
-                tld_pos = -1
-            if tld_pos >= 0:
-                # if tld is located after found link - no need to check fuzzy pattern
-                if self._index < 0 or tld_pos < self._index:
-                    if self._opts.get("fuzzy_ip"):
-                        pattern = self.re["link_fuzzy"]
-                    else:
-                        pattern = self.re["link_no_ip_fuzzy"]
+            if re.search(self.re["host_fuzzy_test"], text, flags=re.IGNORECASE):
+                if self._opts.get("fuzzy_ip"):
+                    pattern = self.re["link_fuzzy"]
+                else:
+                    pattern = self.re["link_no_ip_fuzzy"]
 
-                    ml = re.search(pattern, text, flags=re.IGNORECASE)
-                    if ml:
-                        shift = ml.start(0) + len(ml.groups()[0])
-
-                        if self._index < 0 or shift < self._index:
-                            self._schema = ""
-                            self._index = shift
-                            self._last_index = ml.start(0) + len(ml.group())
+                if re.search(pattern, text, flags=re.IGNORECASE):
+                    return True
 
         if self._opts.get("fuzzy_email") and self._compiled.get("mailto:"):
             # guess schemaless emails
@@ -468,21 +471,10 @@ class LinkifyIt:
             if at_pos >= 0:
                 # We can't skip this check, because this cases are possible:
                 # 192.168.1.1@gmail.com, my.in@example.com
-                me = re.search(self.re["email_fuzzy"], text, flags=re.IGNORECASE)
-                if me:
-                    shift = me.start(0) + len(me.groups()[0])
-                    next_shift = me.start(0) + len(me.group())
+                if re.search(self.re["email_fuzzy"], text, flags=re.IGNORECASE):
+                    return True
 
-                    if (
-                        self._index < 0
-                        or shift < self._index
-                        or (shift == self._index and next_shift > self._last_index)
-                    ):
-                        self._schema = "mailto:"
-                        self._index = shift
-                        self._last_index = next_shift
-
-        return self._index >= 0
+        return False
 
     def pretest(self, text):
         """Very quick check, that can give false positives.
@@ -537,23 +529,94 @@ class LinkifyIt:
                 * **text** - normalized text
                 * **url** - link, generated from matched text
         """
-        shift = 0
+        if not len(text):
+            return None
+
+        # Collect every hit of each pattern in one pass over the whole text.
+        schemed = []
+        fuzzy_link = []
+        fuzzy_email = []
+
+        # scan for links with schema
+        if re.search(self.re["schema_test"], text, flags=re.IGNORECASE):
+            matched_iter = re.finditer(
+                self.re["schema_search"], text, flags=re.IGNORECASE
+            )
+            for matched in matched_iter:
+                length = self.test_schema_at(text, matched.group(2), matched.end(0))
+                if length:
+                    schemed.append(
+                        _Candidate(
+                            matched.group(2),
+                            matched.start(0) + len(matched.group(1)),
+                            matched.start(0) + len(matched.group(0)) + length,
+                        )
+                    )
+
+        if self._opts.get("fuzzy_link") and self._compiled.get("http:"):
+            # guess schemaless links
+            if self._opts.get("fuzzy_ip"):
+                pattern = self.re["link_fuzzy"]
+            else:
+                pattern = self.re["link_no_ip_fuzzy"]
+
+            for matched in re.finditer(pattern, text, flags=re.IGNORECASE):
+                fuzzy_link.append(
+                    _Candidate(
+                        "",
+                        matched.start(0) + len(matched.group(1)),
+                        matched.start(0) + len(matched.group(0)),
+                    )
+                )
+
+        if self._opts.get("fuzzy_email") and self._compiled.get("mailto:"):
+            # guess schemaless emails
+            matched_iter = re.finditer(
+                self.re["email_fuzzy"], text, flags=re.IGNORECASE
+            )
+            for matched in matched_iter:
+                fuzzy_email.append(
+                    _Candidate(
+                        "mailto:",
+                        matched.start(0) + len(matched.group(1)),
+                        matched.start(0) + len(matched.group(0)),
+                    )
+                )
+
+        # Merge the three streams, which are each already sorted by position,
+        # dropping candidates that overlap a match already emitted.
+        indexes = [0, 0, 0]
         result = []
+        last_index = 0
 
-        # try to take previous element from cache, if .test() called before
-        if self._index >= 0 and self._text_cache == text:
-            result.append(self._create_match(shift))
-            shift = self._last_index
+        while True:
+            candidates = [
+                _at(schemed, indexes[0]),
+                _at(fuzzy_email, indexes[1]),
+                _at(fuzzy_link, indexes[2]),
+            ]
 
-        # Cut head if cache was used
-        tail = text[shift:] if shift else text
+            candidate = _choose(_choose(candidates[0], candidates[1]), candidates[2])
 
-        # Scan string until end reached
-        while self.test(tail):
-            result.append(self._create_match(shift))
+            if candidate is None:
+                break
 
-            tail = tail[self._last_index :]
-            shift += self._last_index
+            if candidate is candidates[0]:
+                indexes[0] += 1
+            elif candidate is candidates[1]:
+                indexes[1] += 1
+            else:
+                indexes[2] += 1
+
+            if candidate.index < last_index:
+                continue
+
+            result.append(
+                self._create_match(
+                    text, candidate.schema, candidate.index, candidate.last_index
+                )
+            )
+            last_index = candidate.last_index
 
         if len(result):
             return result
@@ -570,10 +633,6 @@ class LinkifyIt:
         Retuns:
             ``Match`` or ``None``
         """
-        # Reset scan cache
-        self._text_cache = text
-        self._index = -1
-
         if not len(text):
             return None
 
@@ -581,16 +640,16 @@ class LinkifyIt:
         if not founds:
             return None
 
-        m = (founds.group(), founds.groups()[0], founds.groups()[1])
-        length = self.test_schema_at(text, m[2], len(m[0]))
+        length = self.test_schema_at(text, founds.group(2), len(founds.group(0)))
         if not length:
             return None
 
-        self._schema = m[2]
-        self._index = founds.start(0) + len(m[1])
-        self._last_index = founds.start(0) + len(m[0]) + length
-
-        return self._create_match(0)
+        return self._create_match(
+            text,
+            founds.group(2),
+            founds.start(0) + len(founds.group(1)),
+            founds.start(0) + len(founds.group(0)) + length,
+        )
 
     def tlds(self, list_tlds, keep_old=False):
         """Load (or merge) new tlds list. (chainable)

--- a/linkify_it/main.py
+++ b/linkify_it/main.py
@@ -145,33 +145,38 @@ class LinkifyIt:
             Default: {"fuzzy_link": True, "fuzzy_email": True, "fuzzy_ip": False}.
     """
 
+    # The built-in validators match at `pos` with a compiled pattern rather than
+    # running an `^`-anchored search over `text[pos:]` the way upstream does.
+    # The slice is an O(n) copy, and Python 3.10 does not apply the `^` anchor
+    # optimization, so `re.search` rescans the whole tail -- together that is
+    # quadratic on inputs like `mailto:mailto:...`. Schemas registered through
+    # `add()` keep the sliced form: their patterns are documented to start
+    # with `^`, which cannot match at a non-zero position.
+
     def _validate_http(self, text, pos):
-        tail = text[pos:]
         if not self.re.get("http"):
             # compile lazily, because "host"-containing variables can change on
             # tlds update.
-            self.re["http"] = (
-                "^\\/\\/"
+            self.re["http"] = re.compile(
+                "\\/\\/"
                 + self.re["src_auth"]
                 + self.re["src_host_port_strict"]
-                + self.re["src_path"]
+                + self.re["src_path"],
+                flags=re.IGNORECASE,
             )
 
-        founds = re.search(self.re["http"], tail, flags=re.IGNORECASE)
+        founds = self.re["http"].match(text, pos)
         if founds:
             return len(founds.group())
 
         return 0
 
     def _validate_double_slash(self, text, pos):
-        tail = text[pos:]
-
         if not self.re.get("not_http"):
             # compile lazily, because "host"-containing variables can change on
             # tlds update.
-            self.re["not_http"] = (
-                "^"
-                + self.re["src_auth"]
+            self.re["not_http"] = re.compile(
+                self.re["src_auth"]
                 + "(?:localhost|(?:(?:"
                 + self.re["src_domain"]
                 + ")\\.)+"
@@ -179,10 +184,11 @@ class LinkifyIt:
                 + ")"
                 + self.re["src_port"]
                 + self.re["src_host_terminator"]
-                + self.re["src_path"]
+                + self.re["src_path"],
+                flags=re.IGNORECASE,
             )
 
-        founds = re.search(self.re["not_http"], tail, flags=re.IGNORECASE)
+        founds = self.re["not_http"].match(text, pos)
         if founds:
             if pos >= 3 and text[pos - 3] == ":":
                 return 0
@@ -195,14 +201,13 @@ class LinkifyIt:
         return 0
 
     def _validate_mailto(self, text, pos):
-        tail = text[pos:]
-
         if not self.re.get("mailto"):
-            self.re["mailto"] = (
-                "^" + self.re["src_email_name"] + "@" + self.re["src_host_strict"]
+            self.re["mailto"] = re.compile(
+                self.re["src_email_name"] + "@" + self.re["src_host_strict"],
+                flags=re.IGNORECASE,
             )
 
-        founds = re.search(self.re["mailto"], tail, flags=re.IGNORECASE)
+        founds = self.re["mailto"].match(text, pos)
         if founds:
             return len(founds.group(0))
 

--- a/linkify_it/ucre.py
+++ b/linkify_it/ucre.py
@@ -32,7 +32,9 @@ SRC_IP4 = (
 )
 
 # Prohibit any of "@/[]()" in user/pass to avoid wrong domain fetch.
-SRC_AUTH = "(?:(?:(?!" + SRC_ZCC + "|[@/\\[\\]()]).)+@)?"
+# Length is capped to exclude possible rescans till the end and avoid O(n^2)
+# DoS. No standard limit, just take something reasonable.
+SRC_AUTH = "(?:(?:(?!" + SRC_ZCC + "|[@/\\[\\]()]).){1,50}@)?"
 
 SRC_PORT = (
     "(?::(?:6(?:[0-4]\\d{3}|5(?:[0-4]\\d{2}|5(?:[0-2]\\d|3[0-5])))|[1-5]?\\d{1,4}))?"
@@ -40,7 +42,9 @@ SRC_PORT = (
 
 # Allow anything in markdown spec, forbid quote (") at the first position
 # because emails enclosed in quotes are far more common
-SRC_EMAIL_NAME = '[\\-:&=\\+\\$,\\.a-zA-Z0-9_][\\-:&=\\+\\$,\\"\\.a-zA-Z0-9_]*'
+# Max name length capped to 64 chars (RFC 5321). This also prevents O(n^2)
+# rescans to the end on inputs like `mailto:mailto:...`
+SRC_EMAIL_NAME = '[\\-:&=\\+\\$,\\.a-zA-Z0-9_][\\-:&=\\+\\$,\\"\\.a-zA-Z0-9_]{0,63}'
 
 SRC_XN = "xn--[a-z0-9\\-]{1,59}"
 

--- a/linkify_it/ucre.py
+++ b/linkify_it/ucre.py
@@ -44,7 +44,7 @@ SRC_PORT = (
 # because emails enclosed in quotes are far more common
 # Max name length capped to 64 chars (RFC 5321). This also prevents O(n^2)
 # rescans to the end on inputs like `mailto:mailto:...`
-SRC_EMAIL_NAME = '[\\-:&=\\+\\$,\\.a-zA-Z0-9_][\\-:&=\\+\\$,\\"\\.a-zA-Z0-9_]{0,63}'
+SRC_EMAIL_NAME = '[\\-;:&=\\+\\$,\\.a-zA-Z0-9_][\\-;:&=\\+\\$,\\"\\.a-zA-Z0-9_]{0,63}'
 
 SRC_XN = "xn--[a-z0-9\\-]{1,59}"
 

--- a/port.yml
+++ b/port.yml
@@ -1,5 +1,5 @@
 - package: markdown-it/linkify-it
   url: https://github.com/markdown-it/linkify-it
-  version: 5.0.1
-  commit: 0b72d37950f8eb373f8c233070af4b31ebfec285
-  date: May 23, 2026
+  version: 5.0.2
+  commit: 50a0c914f834b201cab25ff4faefd1f832b37332
+  date: Jul 3, 2026

--- a/port.yml
+++ b/port.yml
@@ -1,5 +1,5 @@
 - package: markdown-it/linkify-it
   url: https://github.com/markdown-it/linkify-it
-  version: 5.0.0
-  commit: 5e79093543092562b4348ea58395110357f3d296
-  date: Dec 2, 2023
+  version: 5.0.1
+  commit: 0b72d37950f8eb373f8c233070af4b31ebfec285
+  date: May 23, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest", "coverage", "pytest-cov"]
+test = ["pytest", "coverage", "pytest-cov", "pytest-timeout"]
 dev = ["pre-commit", "isort", "flake8", "black", "pyproject-flake8"]
 benchmark = ["pytest", "pytest-benchmark"]
 doc = ["sphinx", "sphinx_book_theme", "myst-parser"]

--- a/test/fixtures/port_links.txt
+++ b/test/fixtures/port_links.txt
@@ -1,0 +1,17 @@
+%
+% Cases that fail only in this port, not in upstream linkify-it.
+%
+
+%
+% `;` in the email name. Upstream's src_email_name has allowed it since 5.0.0,
+% but this port dropped it from both halves of the character class.
+%
+a;b@example.com
+
+foo;bar;baz@example.com
+
+;a@example.com
+
+a;@example.com
+
+mailto:a;b@example.com

--- a/test/test_apis.py
+++ b/test/test_apis.py
@@ -23,8 +23,7 @@ def test_create_instance_with_schemas():
 
 
 def test_match_class():
-    linkifyit = LinkifyIt()
-    match = Match(linkifyit, 0)
+    match = Match("", "", -1, -1)
     assert (
         match.__repr__()
         == "linkify_it.main.Match({'schema': '', 'index': -1, 'last_index': -1, 'raw': '', 'text': '', 'url': ''})"  # noqa: E501

--- a/test/test_pathological.py
+++ b/test/test_pathological.py
@@ -1,0 +1,19 @@
+"""Inputs that used to make the scan loop degrade to O(n^2)."""
+
+import pytest
+
+from linkify_it import LinkifyIt
+
+TIMEOUT_SECONDS = 10
+
+
+@pytest.mark.timeout(TIMEOUT_SECONDS)
+def test_should_not_hang_on_fuzzy_links_followed_by_an_email_marker():
+    # ~1 MiB input
+    LinkifyIt().match("a.com " * 174762 + "@")
+
+
+@pytest.mark.timeout(TIMEOUT_SECONDS)
+def test_should_not_hang_on_fuzzy_emails_followed_by_a_link_marker():
+    # ~1 MiB input
+    LinkifyIt().match("a@b.com " * 131071 + ".com")

--- a/test/test_pathological.py
+++ b/test/test_pathological.py
@@ -17,3 +17,11 @@ def test_should_not_hang_on_fuzzy_links_followed_by_an_email_marker():
 def test_should_not_hang_on_fuzzy_emails_followed_by_a_link_marker():
     # ~1 MiB input
     LinkifyIt().match("a@b.com " * 131071 + ".com")
+
+
+@pytest.mark.timeout(TIMEOUT_SECONDS)
+def test_should_not_hang_on_repeated_mailto_schema_prefixes():
+    # ~680 KiB input. The ":" in mailto's prefix is also a valid email-name
+    # char, so "mailto:mailto:..." chains into O(n) schema hits, each running
+    # the mailto validator to the end of the tail => O(n^2) without a fix.
+    LinkifyIt().match("mailto:" * 100000)

--- a/test/test_port_parity.py
+++ b/test/test_port_parity.py
@@ -1,0 +1,34 @@
+"""Links that linkify-it recognizes but this port did not, due to port bugs.
+
+Kept apart from test_linkify.py so that upstream's own fixtures stay byte
+identical with linkify-it and remain diffable on the next port.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from linkify_it import LinkifyIt
+
+from .utils import read_fixture_file
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures"
+
+
+def dummy(_):
+    pass
+
+
+@pytest.mark.parametrize(
+    "number,line,expected",
+    read_fixture_file(FIXTURE_PATH.joinpath("port_links.txt")),
+)
+def test_port_links(number, line, expected):
+    linkifyit = LinkifyIt(options={"fuzzy_ip": True})
+
+    linkifyit.normalize = dummy
+
+    assert linkifyit.pretest(line) is True
+    assert linkifyit.test("\n" + line + "\n") is True
+    assert linkifyit.test(line) is True
+    assert linkifyit.match(line)[0].url == expected


### PR DESCRIPTION
## Overview

Ports the two missing upstream security fixes and one parity fix.

| payload, 64 KB | before | after |
| --- | ---: | ---: |
| `"a@b.com "` repeated | 57.5 s | 0.05 s |
| `"mailto:"` repeated | 1.8 s | 0.02 s |

## Changes

- Port linkify-it 5.0.1 scan-loop fix (CVE-2026-48801).
- Port linkify-it 5.0.2 scan-length caps (CVE-2026-59887).
- Allow `;` in email local parts for upstream parity.
- Add regression tests and a quadratic-scan benchmark.
- Keep upstream test fixtures byte-identical; port-only cases go in `port_links.txt`.